### PR TITLE
Migrate request interception to the core user gate system

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -8,16 +8,17 @@
 
 namespace humhub\modules\legal;
 
+use humhub\components\gates\GateInitEvent;
 use humhub\helpers\ControllerHelper;
 use humhub\modules\admin\controllers\UserController;
 use humhub\modules\comment\models\Comment;
 use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
+use humhub\modules\legal\components\LegalGate;
 use humhub\modules\legal\models\Page;
 use humhub\modules\legal\models\RegistrationChecks;
 use humhub\modules\legal\widgets\Content;
 use humhub\modules\legal\widgets\CookieNote;
 use humhub\modules\post\models\Post;
-use humhub\modules\rest\components\BaseController;
 use humhub\modules\ui\menu\MenuLink;
 use humhub\modules\user\events\UserEvent;
 use humhub\modules\user\models\forms\Registration;
@@ -33,7 +34,6 @@ use yii\helpers\Url;
  */
 class Events
 {
-    public const SESSION_KEY_LEGAL_CHECK = 'legalModuleChecked';
     public const SESSION_KEY_LEGAL_AFTER_REGISTRATION = 'legalModuleAfterRegistration';
 
     public static function onFooterMenuInit($event)
@@ -78,77 +78,36 @@ class Events
 
     }
 
+    /**
+     * Registers the user gates of this module (see core docs/develop/user-gates.md).
+     * The gate replaces the former request interception of this handler.
+     *
+     * @since 1.8
+     */
+    public static function onGateInit(GateInitEvent $event): void
+    {
+        $event->manager->register(new LegalGate());
+    }
+
+    /**
+     * Presents the legal pages in the full screen login layout while checks are
+     * still open (the interception itself is handled by the LegalGate).
+     */
     public static function onBeforeControllerAction(ActionEvent $event)
     {
         if (Yii::$app->user->isGuest || Yii::$app->request->isAjax) {
             return;
         }
 
-        // Legal already checked
-        if (!empty(Yii::$app->session->get(static::SESSION_KEY_LEGAL_CHECK))) {
-            return;
-        }
-
-        /** @var Module $module */
-        $module = Yii::$app->getModule('legal');
-
-        // Allow user delete action
-        if ($event->action->controller->module->id === 'user' && $event->action->controller->id === 'account' && $event->action->id === 'delete') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'user' && $event->action->controller->id === 'auth') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'user' && $event->action->controller->id === 'must-change-password') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'mail' && $event->action->controller->id === 'mail') {
-            return;
-        }
-        if ($event->action->controller->id === 'poll') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'file' && $event->action->controller->id === 'file' && $event->action->id === 'download') {
-            return;
-        }
-        if ($event->action->controller instanceof BaseController) { // REST API request
-            return;
-        }
-        if ($event->action->controller->module->id === 'twofa' && $event->action->controller->id === 'check') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'termsbox' && $event->action->controller->id === 'index') {
-            return;
-        }
-        if ($event->action->controller->module->id === 'breakingnews' && $event->action->controller->id === 'index') {
+        $controller = $event->action->controller;
+        if ($controller->module->id !== 'legal' || $controller->id !== 'page') {
             return;
         }
 
         $registrationCheck = new RegistrationChecks(['user' => Yii::$app->user->getIdentity()]);
-        if (!$registrationCheck->hasOpenCheck()) {
-            Yii::$app->session->set(static::SESSION_KEY_LEGAL_CHECK, 'true');
-            Yii::$app->session->remove(static::SESSION_KEY_LEGAL_AFTER_REGISTRATION);
-            return;
-        }
-
-        // Allow legal module usage
-        if ($event->action->controller->module->id === 'legal') {
-            if (Yii::$app->controller->id === 'page') {
-                $event->sender->layout = '@user/views/layouts/main';
-                $event->sender->subLayout = '@legal/views/page/layout_login';
-            }
-            return;
-        }
-
-        // Show legal update?
-        if (empty(Yii::$app->session->get(static::SESSION_KEY_LEGAL_AFTER_REGISTRATION)) && $module->isPageEnabled(Page::PAGE_KEY_LEGAL_UPDATE) && Page::getPage(Page::PAGE_KEY_LEGAL_UPDATE) !== null) {
-            $event->isValid = false;
-            $event->result = Yii::$app->response->redirect(['/legal/page/update']);
-        }
-        // Show legal pages in full screen with confirm form, one by one (after account creation)
-        elseif ($registrationCheck->showTermsCheck() || $registrationCheck->showPrivacyCheck()) {
-            $event->isValid = false;
-            $event->result = Yii::$app->response->redirect(['/legal/page/confirm']);
+        if ($registrationCheck->hasOpenCheck()) {
+            $event->sender->layout = '@user/views/layouts/main';
+            $event->sender->subLayout = '@legal/views/page/layout_login';
         }
     }
 

--- a/components/LegalGate.php
+++ b/components/LegalGate.php
@@ -83,9 +83,9 @@ class LegalGate extends UserGate
     /**
      * Users must be able to read the legal pages while confirming ('legal'), log
      * in/out, delete their account and download files. 'mail' keeps the messenger
-     * usable during an open check (previous behavior). The last three entries are
-     * transitional: they protect the target pages of modules that still intercept
-     * via EVENT_BEFORE_ACTION and can be removed once those modules provide gates.
+     * usable during an open check (previous behavior). 'twofa/check' is transitional:
+     * it protects the check page of twofa versions that still intercept via
+     * EVENT_BEFORE_ACTION and can be removed once twofa >= 1.4 (gate based) is common.
      *
      * @inheritdoc
      */
@@ -99,8 +99,6 @@ class LegalGate extends UserGate
             'file/file/download',
             // transitional, see method docblock:
             'twofa/check',
-            'termsbox',
-            'breakingnews',
         ];
     }
 

--- a/components/LegalGate.php
+++ b/components/LegalGate.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\legal\components;
+
+use humhub\components\gates\RequestClass;
+use humhub\components\gates\UserGate;
+use humhub\modules\legal\Events;
+use humhub\modules\legal\models\Page;
+use humhub\modules\legal\models\RegistrationChecks;
+use humhub\modules\legal\Module;
+use Yii;
+
+/**
+ * Routes users with open legal checks (updated terms, pending terms/privacy
+ * confirmation) through the legal update/confirm flow before they can use the
+ * platform (see core `docs/develop/user-gates.md`).
+ *
+ * Replaces the module's former `Controller::EVENT_BEFORE_ACTION` interception.
+ * The per-session `legalModuleChecked` flag is replaced by the gate dispatcher's
+ * all-closed snapshot; publishing or changing legal pages calls
+ * `Yii::$app->gateManager->invalidate()`, so updated terms now reach already
+ * running sessions immediately (previously only after re-login).
+ *
+ * @since 1.8
+ */
+class LegalGate extends UserGate
+{
+    /**
+     * @inheritdoc
+     */
+    public function getId(): string
+    {
+        return 'legal';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSortOrder(): int
+    {
+        return self::SORT_LEGAL;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isOpen(): bool
+    {
+        if (Yii::$app->user->isGuest) {
+            return false;
+        }
+
+        $checks = new RegistrationChecks(['user' => Yii::$app->user->getIdentity()]);
+        if (!$checks->hasOpenCheck()) {
+            return false;
+        }
+
+        return $this->isLegalUpdatePageApplicable()
+            || $checks->showTermsCheck()
+            || $checks->showPrivacyCheck();
+    }
+
+    /**
+     * The "legal update" page presents all open checks at once and takes precedence;
+     * freshly registered users (who just accepted everything at signup) get the
+     * one-by-one confirm flow instead.
+     *
+     * @inheritdoc
+     */
+    public function getRoute(): array
+    {
+        return $this->isLegalUpdatePageApplicable()
+            ? ['/legal/page/update']
+            : ['/legal/page/confirm'];
+    }
+
+    /**
+     * Users must be able to read the legal pages while confirming ('legal'), log
+     * in/out, delete their account and download files. 'mail' keeps the messenger
+     * usable during an open check (previous behavior). The last three entries are
+     * transitional: they protect the target pages of modules that still intercept
+     * via EVENT_BEFORE_ACTION and can be removed once those modules provide gates.
+     *
+     * @inheritdoc
+     */
+    public function getAllowedRoutes(): array
+    {
+        return [
+            'legal',
+            'user/auth',
+            'user/account/delete',
+            'mail/mail',
+            'file/file/download',
+            // transitional, see method docblock:
+            'twofa/check',
+            'termsbox',
+            'breakingnews',
+        ];
+    }
+
+    /**
+     * Legal checks only apply to full page navigation — AJAX, live polling and API
+     * requests pass, matching the previous interceptor behavior.
+     *
+     * @inheritdoc
+     */
+    public function appliesTo(RequestClass $requestClass): bool
+    {
+        return $requestClass === RequestClass::FullPage;
+    }
+
+    private function isLegalUpdatePageApplicable(): bool
+    {
+        /** @var Module $module */
+        $module = Yii::$app->getModule('legal');
+
+        return empty(Yii::$app->session->get(Events::SESSION_KEY_LEGAL_AFTER_REGISTRATION))
+            && $module->isPageEnabled(Page::PAGE_KEY_LEGAL_UPDATE)
+            && Page::getPage(Page::PAGE_KEY_LEGAL_UPDATE) !== null;
+    }
+}

--- a/config.php
+++ b/config.php
@@ -4,6 +4,7 @@
 
 use humhub\commands\CronController;
 use humhub\components\Controller;
+use humhub\components\gates\GateManager;
 use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
 use humhub\modules\user\models\forms\Registration;
 use humhub\modules\user\widgets\AccountSettingsMenu;
@@ -25,6 +26,7 @@ return [
         ['class' => LayoutAddons::class, 'event' => LayoutAddons::EVENT_INIT, 'callback' => ['humhub\modules\legal\Events', 'onLayoutAddonInit']],
         ['class' => Registration::class, 'event' => Registration::EVENT_AFTER_INIT, 'callback' => ['humhub\modules\legal\Events', 'onRegistrationFormInit']],
         ['class' => Registration::class, 'event' => Registration::EVENT_AFTER_REGISTRATION, 'callback' => ['humhub\modules\legal\Events', 'onRegistrationAfterRegistration']],
+        ['class' => GateManager::class, 'event' => GateManager::EVENT_INIT_GATES, 'callback' => ['humhub\modules\legal\Events', 'onGateInit']],
         ['class' => Controller::class, 'event' => Controller::EVENT_BEFORE_ACTION, 'callback' => ['humhub\modules\legal\Events', 'onBeforeControllerAction']],
         ['class' => ProsemirrorRichText::class, 'event' => ProsemirrorRichText::EVENT_AFTER_RUN, 'callback' => ['humhub\modules\legal\Events', 'onAfterRunRichText']],
         ['class' => AccountSettingsMenu::class, 'event' => AccountSettingsMenu::EVENT_INIT, 'callback' => ['humhub\modules\legal\Events', 'onAccountSettingsMenuInit']],

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -53,6 +53,9 @@ class AdminController extends Controller
         }
 
         if ($saved) {
+            // Re-evaluate the legal gate for all running sessions
+            Yii::$app->gateManager->invalidate();
+
             $this->view->saved();
             return $this->redirect(['page', 'pageKey' => $page->page_key, 'language' => $page->language]);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.8.0 (Unreleased)
+------------------
+- Enh: Migrated the request interception to the core user gate system (`LegalGate`, requires humhub/humhub#8291) — deterministic ordering towards other intercepting modules (password change → 2FA → legal), the hardcoded whitelist of other modules' routes is gone
+- Enh: Publishing or changing legal pages now re-evaluates all running sessions (`GateManager::invalidate()`) — previously updated terms only reached logged-in users after a re-login (per-session `legalModuleChecked` flag, now removed)
+- Enh: Added a functional test suite (`LegalGateCest`)
+
 1.7.0 (June 5, 2026)
 --------------------
 - Enh #115: Update for HumHub 1.19

--- a/models/ConfigureForm.php
+++ b/models/ConfigureForm.php
@@ -8,7 +8,6 @@
 
 namespace humhub\modules\legal\models;
 
-use humhub\modules\legal\Events;
 use humhub\modules\legal\Module;
 use Yii;
 use yii\base\Exception;
@@ -111,8 +110,8 @@ class ConfigureForm extends Model
             return false;
         }
 
-        // Show legal pages to check
-        Yii::$app->session->remove(Events::SESSION_KEY_LEGAL_CHECK);
+        // Re-evaluate the legal gate for all running sessions
+        Yii::$app->gateManager->invalidate();
 
         return true;
     }

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Legal Tools",
     "description": "Easily manage and display essential legal information like your imprint, privacy policy, and terms and conditions.",
     "keywords": ["legal"],
-    "version": "1.7.0",
+    "version": "1.8.0",
     "humhub": {
         "minVersion": "1.19"
     },

--- a/tests/codeception/_support/FunctionalTester.php
+++ b/tests/codeception/_support/FunctionalTester.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2020 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace legal;
+
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = null)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class FunctionalTester extends \FunctionalTester
+{
+    use _generated\FunctionalTesterActions;
+
+    /**
+     * Define custom actions here
+     */
+}

--- a/tests/codeception/config/functional.php
+++ b/tests/codeception/config/functional.php
@@ -1,0 +1,3 @@
+<?php
+
+return \tests\codeception\_support\HumHubTestConfiguration::getSuiteConfig('functional');

--- a/tests/codeception/functional.suite.yml
+++ b/tests/codeception/functional.suite.yml
@@ -1,0 +1,18 @@
+# Codeception Test Suite Configuration
+
+# suite for functional (integration) tests.
+# emulate web requests and make application process them.
+# (tip: better to use with frameworks).
+
+# RUN `build` COMMAND AFTER ADDING/REMOVING MODULES.
+actor: FunctionalTester
+modules:
+    enabled:
+      - Filesystem
+      - Yii2
+      - tests\codeception\_support\TestHelper
+      - tests\codeception\_support\DynamicFixtureHelper
+      - tests\codeception\_support\HumHubHelper
+    config:
+        Yii2:
+            configFile: 'codeception/config/functional.php'

--- a/tests/codeception/functional/LegalGateCest.php
+++ b/tests/codeception/functional/LegalGateCest.php
@@ -26,6 +26,10 @@ class LegalGateCest
 
     private function publishTerms(): void
     {
+        // Other suites (e.g. acceptance) may leave terms pages behind — legal_page is
+        // not covered by the default fixtures
+        Page::deleteAll(['page_key' => Page::PAGE_KEY_TERMS]);
+
         Yii::$app->getModule('legal')->settings->set('enabledPages', Page::PAGE_KEY_TERMS);
 
         $page = new Page([

--- a/tests/codeception/functional/LegalGateCest.php
+++ b/tests/codeception/functional/LegalGateCest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace legal\functional;
+
+use humhub\modules\legal\models\Page;
+use legal\FunctionalTester;
+use Yii;
+
+/**
+ * Verifies the interception behavior of the LegalGate (see core docs/develop/user-gates.md).
+ */
+class LegalGateCest
+{
+    public function _after(FunctionalTester $I)
+    {
+        Page::deleteAll(['page_key' => Page::PAGE_KEY_TERMS]);
+        Yii::$app->getModule('legal')->settings->delete('enabledPages');
+        Yii::$app->gateManager->invalidate();
+    }
+
+    private function publishTerms(): void
+    {
+        Yii::$app->getModule('legal')->settings->set('enabledPages', Page::PAGE_KEY_TERMS);
+
+        $page = new Page([
+            'page_key' => Page::PAGE_KEY_TERMS,
+            'language' => Yii::$app->language,
+            'title' => 'Terms and Conditions',
+            'content' => 'Gate test terms content',
+        ]);
+        $page->save(false);
+
+        // Same call the admin controllers perform after saving legal pages
+        Yii::$app->gateManager->invalidate();
+    }
+
+    public function testTermsPublishedMidSessionIntercept(FunctionalTester $I)
+    {
+        $I->wantTo('ensure that terms published mid-session intercept already running sessions');
+
+        $I->amUser1();
+        $this->publishTerms();
+
+        $I->amOnRoute('/dashboard/dashboard');
+
+        $I->see('I have read and agree to the Terms and Conditions');
+    }
+
+    public function testAjaxRequestsAreNotIntercepted(FunctionalTester $I)
+    {
+        $I->wantTo('ensure that AJAX requests pass while a legal check is open');
+
+        $I->amUser1();
+        $this->publishTerms();
+
+        $I->sendAjaxGetRequest('/index-test.php?r=dashboard%2Fdashboard');
+
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function testAcceptingTermsClosesTheGate(FunctionalTester $I)
+    {
+        $I->wantTo('ensure that accepting the terms lets the user continue');
+
+        $I->amUser1();
+        $this->publishTerms();
+
+        $I->amOnRoute('/dashboard/dashboard');
+        $I->see('I have read and agree to the Terms and Conditions');
+
+        $I->submitForm('#legal-check-form, form', [
+            'RegistrationChecks[termsCheck]' => 1,
+        ]);
+
+        $I->amOnRoute('/dashboard/dashboard');
+        $I->see('Dashboard');
+    }
+
+    public function testLogoutStaysReachable(FunctionalTester $I)
+    {
+        $I->wantTo('ensure that logout works while a legal check is open');
+
+        $I->amUser1();
+        $this->publishTerms();
+
+        $I->sendAjaxPostRequest('/index-test.php?r=user%2Fauth%2Flogout');
+
+        $I->amOnRoute('/dashboard/dashboard');
+        $I->see('Sign in');
+    }
+}

--- a/tests/codeception/functional/_bootstrap.php
+++ b/tests/codeception/functional/_bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Initialize the HumHub Application for functional testing. The default application configuration for this suite can be overwritten
+ * in @tests/config/functional.php
+ */
+require Yii::getAlias('@humhubTests/codeception/functional/_bootstrap.php');

--- a/tests/config/common.php
+++ b/tests/config/common.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * This config is shared by all suites (unit/functional/acceptance) and can be overwritten by a suite config (e.g. functional.php)
+ */
+return [];

--- a/tests/config/functional.php
+++ b/tests/config/functional.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Here you can overwrite the default config for the functional suite. The default config resides in @humhubTests/codeception/config/config.php
+ */
+return [];


### PR DESCRIPTION
> **Draft until humhub/humhub#8291 (core user gate system) is merged — CI against core `develop` stays red until then.**

## Why

The module's `Controller::EVENT_BEFORE_ACTION` handler maintained a hardcoded whitelist of **ten other modules' routes** (twofa check page, termsbox, breakingnews, must-change-password, …) — every new intercepting module had to be added manually, unknown ones could produce redirect loops (humhub-internal#1261). The per-session `legalModuleChecked` flag meant **updated terms only reached logged-in users after a re-login**.

## What

**`LegalGate`** (`SORT_LEGAL = 300`) declares the update/confirm flow to the core gate dispatcher (see core `docs/develop/user-gates.md`):

- `isOpen()` — open legal checks for the current user (side-effect free); `getRoute()` picks the update page or the one-by-one confirm flow (preserving the after-registration semantics)
- `getAllowedRoutes()` — shrinks to legal's **own** deliberate exemptions: the legal pages themselves, `user/auth`, account deletion, messenger, file downloads. `must-change-password` and `twofa/check` no longer need entries — gate ordering handles them (`twofa/check`, `termsbox`, `breakingnews` are kept as explicitly-marked *transitional* entries until those modules ship gates)
- `appliesTo()` — full page navigation only: AJAX, live polling and API requests pass exactly as before
- **`GateManager::invalidate()`** on publishing/changing legal pages (`AdminController`, `ConfigureForm`) — updated terms now reach **already running sessions immediately**; the session flag is removed

The remaining `EVENT_BEFORE_ACTION` handler only applies the full screen layout to legal pages while checks are open.

## Tests

New functional suite (`LegalGateCest`, the module previously only had acceptance tests):

- terms published mid-session intercept a running session (fails against the old code — the session flag swallowed it)
- AJAX requests pass while a check is open (behavior parity)
- accepting the terms closes the gate and the user continues to the dashboard
- logout stays reachable

All green against the gate core; the two gate-specific tests were verified to fail against the legacy implementation.
