### PR TITLE
Docs: Pass File object to addExportFile() in export example

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -26,7 +26,7 @@ public static function onLegalModuleUserDataExport(\humhub\modules\legal\events\
 
     $files = File::findAll(['created_by' => $event->user->id]);
     foreach ($files as $file) {
-        $event->addExportFile($file->file_name, $file->store->get());
+        $event->addExportFile($file->file_name, $file);
     }
 }
 ```


### PR DESCRIPTION
Since humhub/humhub#8011, `StorageManager::get()` returns a data-mount-relative path instead of an absolute local filesystem path, so passing it as a string source to `addExportFile()` no longer works (the file would silently be missing from the export ZIP on HumHub 1.19). `addExportFile()` accepts `File` objects, which are read through the Flysystem store and work on any mount — the developer example now shows that variant.

Docs-only change. See humhub/humhub#8310 for the corresponding core fix and migration guide update.